### PR TITLE
fix: Correctly identify modified files

### DIFF
--- a/artefactscomparison/compare.py
+++ b/artefactscomparison/compare.py
@@ -49,7 +49,7 @@ def list_untouched_files(
 def list_renamed_files(
     base: ContentToFilepathMapping, head: ContentToFilepathMapping
 ) -> FilepathMapping:
-    """List artefacts for renamed from base to head.
+    """List artefacts renamed from base to head.
 
     This means their content has not changed, but their file path has.
 
@@ -111,3 +111,23 @@ def list_added_files(
             found in head.
     """
     return [head[artefact_content] for artefact_content in set(head) - set(base)]
+
+
+def list_modified_files(
+    base: ContentToFilepathMapping, head: ContentToFilepathMapping
+) -> FilepathCollection:
+    """List artefacts modified from base to head.
+
+    This means their content has changed, but their file path has not.
+
+    Args:
+        base (ContentToFilepathMapping): Mapping of artefacts content to their
+            filename in the base summary.
+        head (ContentToFilepathMapping): Mapping of artefacts content to their
+            filename in the head summary.
+
+    Returns:
+        FilepathCollection: List of file paths of artefacts which modified
+            between base and head.
+    """
+    raise NotImplementedError()

--- a/artefactscomparison/compare.py
+++ b/artefactscomparison/compare.py
@@ -152,4 +152,12 @@ def list_modified_files(
         FilepathCollection: List of file paths of artefacts which modified
             between base and head.
     """
-    raise NotImplementedError()
+    content_in_base_only = set(base) - set(head)
+    file_paths_in_base_and_head = set(base.values()) & set(head.values())
+
+    return [
+        base[artefact_content]
+        for artefact_content in content_in_base_only
+        # keep files simply modified:
+        if base[artefact_content] in file_paths_in_base_and_head
+    ]

--- a/artefactscomparison/compare.py
+++ b/artefactscomparison/compare.py
@@ -80,7 +80,9 @@ def list_renamed_files(
 def list_deleted_files(
     base: ContentToFilepathMapping, head: ContentToFilepathMapping
 ) -> FilepathCollection:
-    """List deleted artefacts, i.e., those whose content is only found in base.
+    """List deleted artefacts.
+
+    I.e., those for which both file path _and_ content is only found in base.
 
     Args:
         base (ContentToFilepathMapping): Mapping of artefacts content to their
@@ -92,13 +94,24 @@ def list_deleted_files(
         FilepathCollection: List of file paths of artefacts which are only
             found in base.
     """
-    return [base[artefact_content] for artefact_content in set(base) - set(head)]
+    content_in_base_only = set(base) - set(head)
+    file_paths_in_base_and_head = set(base.values()) & set(head.values())
+
+    return [
+        base[artefact_content]
+        for artefact_content in content_in_base_only
+        # ignore files simply modified:
+        if base[artefact_content] not in file_paths_in_base_and_head
+    ]
 
 
 def list_added_files(
     base: ContentToFilepathMapping, head: ContentToFilepathMapping
 ) -> FilepathCollection:
-    """List added artefacts, i.e., those whose content is only found in head.
+    """List added artefacts.
+
+    I.e., artefacts for which both file path _and_ content is only found in
+    head.
 
     Args:
         base (ContentToFilepathMapping): Mapping of artefacts content to their
@@ -110,7 +123,15 @@ def list_added_files(
         FilepathCollection: List of file paths of artefacts which are only
             found in head.
     """
-    return [head[artefact_content] for artefact_content in set(head) - set(base)]
+    content_in_head_only = set(head) - set(base)
+    file_paths_in_base_and_head = set(base.values()) & set(head.values())
+
+    return [
+        head[artefact_content]
+        for artefact_content in content_in_head_only
+        # ignore files simply modified:
+        if head[artefact_content] not in file_paths_in_base_and_head
+    ]
 
 
 def list_modified_files(
@@ -118,7 +139,8 @@ def list_modified_files(
 ) -> FilepathCollection:
     """List artefacts modified from base to head.
 
-    This means their content has changed, but their file path has not.
+    This means their content has changed from base to head,
+    but their file path has not.
 
     Args:
         base (ContentToFilepathMapping): Mapping of artefacts content to their

--- a/artefactscomparison/report.py
+++ b/artefactscomparison/report.py
@@ -7,6 +7,7 @@ from .compare import (
     FilepathMapping,
     list_added_files,
     list_deleted_files,
+    list_modified_files,
     list_renamed_files,
     list_untouched_files,
 )
@@ -34,6 +35,7 @@ class Report:
         """
         self.added_artefacts = list_added_files(self.base, self.head)
         self.deleted_artefacts = list_deleted_files(self.base, self.head)
+        self.modified_artefacts = list_modified_files(self.base, self.head)
         self.renamed_artefacts = list_renamed_files(self.base, self.head)
         self.untouched_artefacts = list_untouched_files(self.base, self.head)
 
@@ -46,6 +48,14 @@ class Report:
             str: Report formatted as a Markdown diff code snippet.
         """
         report = ["```diff"]
+
+        if self.modified_artefacts:
+            report.append(
+                f"@@ {self._print_artefacts_count(self.modified_artefacts)} modified @@"
+            )
+            for filename in sorted(self.modified_artefacts):
+                report.append(f"! {filename}")
+            report.append("")
 
         if self.added_artefacts:
             report.append(

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -15,6 +15,7 @@ def test_list_added_files_when_no_added_file():
         "5": "to_rename_1",
         "6": "to_rename_2",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -23,6 +24,7 @@ def test_list_added_files_when_no_added_file():
         "4": "no_change_4",
         "5": "renamed_1",
         "6": "renamed_2",
+        "420": "modified_1",
     }
     assert list_added_files(base, head) == []
 
@@ -36,6 +38,7 @@ def test_list_added_files_when_one_added_file():
         "5": "to_rename_1",
         "6": "to_rename_2",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -45,6 +48,7 @@ def test_list_added_files_when_one_added_file():
         "5": "renamed_1",
         "6": "renamed_2",
         "8": "added_1",
+        "420": "modified_1",
     }
     assert list_added_files(base, head) == [
         "added_1",
@@ -60,6 +64,7 @@ def test_list_added_files_when_multiple_added_files():
         "5": "to_rename_1",
         "6": "to_rename_2",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -71,6 +76,7 @@ def test_list_added_files_when_multiple_added_files():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
 
     added_filenames_expected = ["added_1", "added_2", "added_3"]
@@ -90,6 +96,7 @@ def test_list_deleted_files_when_no_deleted_file():
         "4": "no_change_4",
         "5": "to_rename_1",
         "6": "to_rename_2",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -101,6 +108,7 @@ def test_list_deleted_files_when_no_deleted_file():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
     assert list_deleted_files(base, head) == []
 
@@ -114,6 +122,7 @@ def test_list_deleted_files_when_one_deleted_file():
         "5": "to_rename_1",
         "6": "to_rename_2",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -125,6 +134,7 @@ def test_list_deleted_files_when_one_deleted_file():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
     assert list_deleted_files(base, head) == [
         "to_be_deleted",
@@ -142,6 +152,7 @@ def test_list_deleted_files_when_multiple_deleted_files():
         "71": "to_be_deleted_1",
         "72": "to_be_deleted_2",
         "73": "to_be_deleted_3",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -153,6 +164,7 @@ def test_list_deleted_files_when_multiple_deleted_files():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
 
     deleted_filenames_expected = [
@@ -175,6 +187,7 @@ def test_list_renamed_files_when_no_renamed_file():
         "3": "no_change_3",
         "4": "no_change_4",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -184,6 +197,7 @@ def test_list_renamed_files_when_no_renamed_file():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
     assert list_renamed_files(base, head) == {}
 
@@ -196,6 +210,7 @@ def test_list_renamed_files_when_one_renamed_file():
         "4": "no_change_4",
         "5": "to_rename_1",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -206,6 +221,7 @@ def test_list_renamed_files_when_one_renamed_file():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
     assert list_renamed_files(base, head) == {"to_rename_1": "renamed_1"}
 
@@ -220,6 +236,7 @@ def test_list_renamed_files_when_multiple_renamed_files():
         "6": "to_rename_2",
         "61": "to_rename_3",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -232,6 +249,7 @@ def test_list_renamed_files_when_multiple_renamed_files():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
 
     assert list_renamed_files(base, head) == {
@@ -246,6 +264,7 @@ def test_list_untouched_files_when_no_untouched_file():
         "5": "to_rename_1",
         "6": "to_rename_2",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "5": "renamed_1",
@@ -253,6 +272,7 @@ def test_list_untouched_files_when_no_untouched_file():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
     assert list_untouched_files(base, head) == []
 
@@ -263,6 +283,7 @@ def test_list_untouched_files_when_one_untouched_file():
         "5": "to_rename_1",
         "6": "to_rename_2",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -271,6 +292,7 @@ def test_list_untouched_files_when_one_untouched_file():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
     assert list_untouched_files(base, head) == [
         "no_change_1",
@@ -286,6 +308,7 @@ def test_list_untouched_files_when_multiple_untouched_files():
         "5": "to_rename_1",
         "6": "to_rename_2",
         "7": "to_be_deleted",
+        "42": "modified_1",
     }
     head = {
         "1": "no_change_1",
@@ -297,6 +320,7 @@ def test_list_untouched_files_when_multiple_untouched_files():
         "8": "added_1",
         "9": "added_2",
         "10": "added_3",
+        "420": "modified_1",
     }
 
     untouched_filenames_expected = [

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,6 +1,7 @@
 from artefactscomparison.compare import (
     list_added_files,
     list_deleted_files,
+    list_modified_files,
     list_renamed_files,
     list_untouched_files,
 )
@@ -335,3 +336,93 @@ def test_list_untouched_files_when_multiple_untouched_files():
     assert len(untouched_filenames_computed) == len(untouched_filenames_expected)
     # Same content, irrespective of order
     assert set(untouched_filenames_computed) == set(untouched_filenames_expected)
+
+
+def test_list_modified_files_when_no_modified_files():
+    base = {
+        "1": "no_change_1",
+        "2": "no_change_2",
+        "3": "no_change_3",
+        "4": "no_change_4",
+        "5": "to_rename_1",
+        "6": "to_rename_2",
+        "7": "to_be_deleted",
+    }
+    head = {
+        "1": "no_change_1",
+        "2": "no_change_2",
+        "3": "no_change_3",
+        "4": "no_change_4",
+        "5": "renamed_1",
+        "6": "renamed_2",
+        "8": "added_1",
+        "9": "added_2",
+        "10": "added_3",
+    }
+
+    assert list_modified_files(base, head) == []
+
+
+def test_list_modified_files_when_one_modified_files():
+    base = {
+        "1": "no_change_1",
+        "2": "no_change_2",
+        "3": "no_change_3",
+        "4": "no_change_4",
+        "5": "to_rename_1",
+        "6": "to_rename_2",
+        "7": "to_be_deleted",
+        "42": "modified_1",
+    }
+    head = {
+        "1": "no_change_1",
+        "2": "no_change_2",
+        "3": "no_change_3",
+        "4": "no_change_4",
+        "5": "renamed_1",
+        "6": "renamed_2",
+        "8": "added_1",
+        "9": "added_2",
+        "10": "added_3",
+        "420": "modified_1",
+    }
+
+    assert list_modified_files(base, head) == ["modified_1"]
+
+
+def test_list_modified_files_when_multiple_modified_files():
+    base = {
+        "1": "no_change_1",
+        "2": "no_change_2",
+        "3": "no_change_3",
+        "4": "no_change_4",
+        "5": "to_rename_1",
+        "6": "to_rename_2",
+        "7": "to_be_deleted",
+        "42": "modified_1",
+        "43": "modified_2",
+    }
+    head = {
+        "1": "no_change_1",
+        "2": "no_change_2",
+        "3": "no_change_3",
+        "4": "no_change_4",
+        "5": "renamed_1",
+        "6": "renamed_2",
+        "8": "added_1",
+        "9": "added_2",
+        "10": "added_3",
+        "420": "modified_1",
+        "430": "modified_2",
+    }
+
+    modified_filenames_expected = [
+        "modified_1",
+        "modified_2",
+    ]
+    modified_filenames_computed = list_modified_files(base, head)
+
+    # Same length
+    assert len(modified_filenames_computed) == len(modified_filenames_expected)
+    # Same content, irrespective of order
+    assert set(modified_filenames_computed) == set(modified_filenames_expected)

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -8,6 +8,7 @@ base = {
     "5": "to_rename_1",
     "6": "to_rename_2",
     "7": "to_be_deleted",
+    "42": "modified_1",
 }
 head = {
     "1": "no_change_1",
@@ -19,6 +20,7 @@ head = {
     "8": "added_1",
     "9": "added_2",
     "10": "added_3",
+    "420": "modified_1",
 }
 
 report = Report(base=base, head=head)
@@ -50,6 +52,8 @@ def test_Report_generate():
     ]
     assert len(report.untouched_artefacts) == len(untouched_artefacts_expected)
     assert set(report.untouched_artefacts) == set(untouched_artefacts_expected)
+
+    assert report.modified_artefacts == ["modified_1"]
 
 
 def test_Report_print_artefacts_count_when_no_file_list():


### PR DESCRIPTION
When a file is simply modified by the build (i.e. its content changes, but not its path), it currently appears as an added and a deleted one:

```diff
@@ 1 file added @@
+ results/file_that_gets_modified.csv

@@ 1 file deleted @@
- results/file_that_gets_modified.csv
```

This PR makes it appear as _modified_ instead:

```diff
@@ 1 file modified @@
! build/path/to/file_that_gets_modified_1

@@ 1 file added @@
+ build/path/to/added_artefact_1

@@ 2 files deleted @@
- build/path/to/artefact_to_delete_1
- build/path/to/artefact_to_delete_2

@@ 3 files renamed @@
! build/path/to/artefact_to_rename_1 ￫ build/path/to/artefact_renamed_1
! build/path/to/artefact_to_rename_2 ￫ build/path/to/artefact_renamed_2
! build/path/to/artefact_to_rename_3 ￫ build/path/to/artefact_renamed_3

# 4 other files remain unmodified
```
